### PR TITLE
Fixed Issue #11 Regression

### DIFF
--- a/falcon-sample/src/androidTest/java/com/jraska/falcon/sample/Assumptions.java
+++ b/falcon-sample/src/androidTest/java/com/jraska/falcon/sample/Assumptions.java
@@ -14,7 +14,4 @@ public final class Assumptions {
     return BuildConfig.CI_BUILD;
   }
 
-  public static void assumePlatformHasDialogIssue() {
-    Assume.assumeTrue(Build.VERSION.SDK_INT <= Build.VERSION_CODES.KITKAT);
-  }
 }

--- a/falcon-sample/src/androidTest/java/com/jraska/falcon/sample/FalconDialogInOnCreateTest.java
+++ b/falcon-sample/src/androidTest/java/com/jraska/falcon/sample/FalconDialogInOnCreateTest.java
@@ -22,8 +22,6 @@ public class FalconDialogInOnCreateTest {
   // Tests https://github.com/jraska/Falcon/issues/11
   @Test
   public void takesDialogOnCreate() {
-    Assumptions.assumePlatformHasDialogIssue();
-
     DialogOnCreate activity = _activityRule.getActivity();
     onView(withText(DialogOnCreate.DIALOG_TITLE)).check(matches(isDisplayed()));
 

--- a/falcon-sample/src/main/java/com/jraska/falcon/sample/DialogOnCreate.java
+++ b/falcon-sample/src/main/java/com/jraska/falcon/sample/DialogOnCreate.java
@@ -6,6 +6,8 @@ import android.support.v7.app.AppCompatActivity;
 
 public class DialogOnCreate extends AppCompatActivity {
   public static final String DIALOG_TITLE = "Title";
+  public static final String DIALOG_MESSAGE = "Message";
+  public static final String DIALOG_POSITIVE_BUTTON = "OK";
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -14,6 +16,8 @@ public class DialogOnCreate extends AppCompatActivity {
 
     new AlertDialog.Builder(this)
         .setTitle(DIALOG_TITLE)
+        .setMessage(DIALOG_MESSAGE)
+        .setPositiveButton(DIALOG_POSITIVE_BUTTON, null)
         .show();
   }
 }

--- a/falcon/src/main/java/com/jraska/falcon/Falcon.java
+++ b/falcon/src/main/java/com/jraska/falcon/Falcon.java
@@ -8,6 +8,7 @@ import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.Rect;
 import android.os.Build;
+import android.os.IBinder;
 import android.os.Looper;
 import android.util.Log;
 import android.view.View;
@@ -293,8 +294,7 @@ public final class Falcon {
         continue;
       }
 
-      Activity dialogOwnerActivity = ownerActivity(viewRoot.context());
-      if (dialogOwnerActivity == null) {
+      if (viewRoot.getWindowToken() == null) {
         // make sure we will never compare null == null
         return;
       }
@@ -302,7 +302,7 @@ public final class Falcon {
       for (int parentIndex = dialogIndex + 1; parentIndex < viewRoots.size(); parentIndex++) {
         ViewRootData possibleParent = viewRoots.get(parentIndex);
         if (possibleParent.isActivityType()
-            && ownerActivity(possibleParent.context()) == dialogOwnerActivity) {
+            && possibleParent.getWindowToken() == viewRoot.getWindowToken()) {
           viewRoots.remove(possibleParent);
           viewRoots.add(dialogIndex, possibleParent);
 
@@ -310,24 +310,6 @@ public final class Falcon {
         }
       }
     }
-  }
-
-  private static Activity ownerActivity(Context context) {
-    Context currentContext = context;
-
-    while (currentContext != null) {
-      if (currentContext instanceof Activity) {
-        return (Activity) currentContext;
-      }
-
-      if (currentContext instanceof ContextWrapper && !(currentContext instanceof Application)) {
-        currentContext = ((ContextWrapper) currentContext).getBaseContext();
-      } else {
-        break;
-      }
-    }
-
-    return null;
   }
 
   private static Object getFieldValue(String fieldName, Object target) {
@@ -420,6 +402,10 @@ public final class Falcon {
 
     boolean isActivityType() {
       return _layoutParams.type == LayoutParams.TYPE_BASE_APPLICATION;
+    }
+
+    IBinder getWindowToken() {
+      return _layoutParams.token;
     }
 
     Context context() {


### PR DESCRIPTION
Issue #11 reported a scenario where a dialog shown from the `Activity#onCreate` would not be captured in a screenshot. The applied fix stopped working as of Android 7 (Nougat) because Google changed how they handled the DecorView (see https://github.com/aosp-mirror/platform_frameworks_base/commit/ff22a56ef88214381cc9955f9a32d0e8d4db228f). Since the context being wrapped is now the Application context instead of the Activity context, the parent activity would never be found and reordered.

This change compares window [tokens](https://developer.android.com/reference/android/view/WindowManager.LayoutParams.html#token) instead of contexts.